### PR TITLE
v0.1.1

### DIFF
--- a/lb/compose.yml
+++ b/lb/compose.yml
@@ -14,7 +14,7 @@ services:
       resources:
         limits:
           cpus: '0.05'
-          memory: 50M
+          memory: 40M
         reservations:
           cpus: '0.05'
           memory: 20M


### PR DESCRIPTION
nginx:
limits:
cpus: '0.05'
memory: 40M
reservations:
cpus: '0.05'
memory: 20M

blog:
limits:
cpus: '0.02'
memory: 50M
reservations:
cpus: '0.01'
memory: 20M